### PR TITLE
[fpgrowth] Fix O3 option

### DIFF
--- a/fpgrowth/src/makefile
+++ b/fpgrowth/src/makefile
@@ -26,9 +26,12 @@ APRIDIR  = ../../apriori/src
 CC       = g++ -std=c++11
 # CC       = g++
 CFBASE   = -Wall -Wextra -Wno-unused-parameter -Wconversion \
-           -pedantic -c $(ADDFLAGS) -fpermissive
-#CFLAGS   = $(CFBASE) -DNDEBUG -O0 -g  -funroll-loops -std=c11
-CFLAGS   = $(CFBASE) -O3  -funroll-loops 
+           -pedantic -c $(ADDFLAGS) -fno-unroll-loops 
+CFBASE	+=-fpermissive
+CFLAGS   = $(CFBASE)  -O3 -g  -std=c++11
+#CFLAGS	+= -funroll-loops
+#CFLAGS   = $(CFBASE) -DNDEBUG -O3 -g  -funroll-loops -std=c++11
+#CFLAGS   = $(CFBASE) -O3  -funroll-loops  
 #CFLAGS   = $(CFBASE) -DNDEBUG -O3 -g -funroll-loops
 # CFLAGS   = $(CFBASE) -DNDEBUG -O3 -funroll-loops -DBENCH
 # CFLAGS   = $(CFBASE) -g


### PR DESCRIPTION
In my computer(`linux 5.15` with `nvidia 1070`), `-O3` will make program error. But when I using `-O0` will generate the correct result. I found that in `void *cst_to_gputree` function has no return. When enable some optimization, compiler will generate error code.

Fix it by adding `return ;` at the end of the `fpgrowth.c:1322`.